### PR TITLE
Add shutdown to sequence of flash commands

### DIFF
--- a/RASLib/Makefile
+++ b/RASLib/Makefile
@@ -78,6 +78,8 @@ flash: $(TARGET)
 	$(GDB) $< -batch -x $(RASLIB)/gdb-script \
 		-ex "monitor reset halt"             \
 		-ex "load"                           \
+		-ex "monitor reset halt"             \
+		-ex "monitor shutdown"		     \
 		-ex "monitor reset run"
 
 debug: $(TARGET)


### PR DESCRIPTION
This allows the board to recover from having been flashed by Keil, which presumably sets a bit that causes erase commands to fail.