### PR TITLE
Revert "Add shutdown to sequence of flash commands"

### DIFF
--- a/RASLib/Makefile
+++ b/RASLib/Makefile
@@ -78,8 +78,6 @@ flash: $(TARGET)
 	$(GDB) $< -batch -x $(RASLIB)/gdb-script \
 		-ex "monitor reset halt"             \
 		-ex "load"                           \
-		-ex "monitor reset halt"             \
-		-ex "monitor shutdown"		     \
 		-ex "monitor reset run"
 
 debug: $(TARGET)


### PR DESCRIPTION
Reverts ut-ras/Rasware#56

Unsupported by the openocd gdbserver.