### PR TITLE
Update Makefile flash target to use openocd directly

### DIFF
--- a/RASDemo/Makefile
+++ b/RASDemo/Makefile
@@ -76,10 +76,12 @@ size: $(TARGET)
 	$(SIZE) $<
 
 flash: $(TARGET)
-	$(GDB) $< -batch -x $(RASLIB)/gdb-script \
-		-ex "monitor reset halt"             \
-		-ex "load"                           \
-		-ex "monitor reset run"
+	$(OPENOCD) -c "init"                              \
+	           -c "halt"                              \
+	           -c "flash write_image erase $(TARGET)" \
+	           -c "verify_image $(TARGET)"            \
+	           -c "halt"                              \
+	           -c "shutdown"
 
 debug: $(TARGET)
 	$(GDB) $< -x $(RASLIB)/gdb-script

--- a/RASLib/Makefile
+++ b/RASLib/Makefile
@@ -75,10 +75,12 @@ size: $(TARGET)
 	$(SIZE) $<
 
 flash: $(TARGET)
-	$(GDB) $< -batch -x $(RASLIB)/gdb-script \
-		-ex "monitor reset halt"             \
-		-ex "load"                           \
-		-ex "monitor reset run"
+	$(OPENOCD) -c "init"                              \
+	           -c "halt"                              \
+	           -c "flash write_image erase $(TARGET)" \
+	           -c "verify_image $(TARGET)"            \
+	           -c "halt"                              \
+	           -c "shutdown"
 
 debug: $(TARGET)
 	$(GDB) $< -x $(RASLIB)/gdb-script

--- a/RASTemplate/Makefile
+++ b/RASTemplate/Makefile
@@ -76,10 +76,12 @@ size: $(TARGET)
 	$(SIZE) $<
 
 flash: $(TARGET)
-	$(GDB) $< -batch -x $(RASLIB)/gdb-script \
-		-ex "monitor reset halt"             \
-		-ex "load"                           \
-		-ex "monitor reset run"
+	$(OPENOCD) -c "init"                              \
+	           -c "halt"                              \
+	           -c "flash write_image erase $(TARGET)" \
+	           -c "verify_image $(TARGET)"            \
+	           -c "halt"                              \
+	           -c "shutdown"
 
 debug: $(TARGET)
 	$(GDB) $< -x $(RASLIB)/gdb-script


### PR DESCRIPTION
Keil evidently sets a bit when flashing that makes openocd commands fail.  Using the openocd "shutdown" command appears to reset the board to where it can be reset/flashed by openocd.  The openocd gdbserver "monitor shutdown" command seems not to work (ut-ras/Rasware#56 and reverted in ut-ras/Rasware#57).