### PR TITLE
Build System Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ StellarisWare/
 *._ia
 .DS_Store
 *.swp
+.detect-board-cache

--- a/RASDemo/Makefile
+++ b/RASDemo/Makefile
@@ -79,7 +79,9 @@ size: $(TARGET)
 
 flash: $(TARGET)
 	$(OPENOCD) -c "init"                              \
+	           -c "reset"                             \
 	           -c "halt"                              \
+	           -c "flash probe 0"                     \
 	           -c "flash write_image erase $(TARGET)" \
 	           -c "verify_image $(TARGET)"            \
 	           -c "halt"                              \

--- a/RASDemo/Makefile
+++ b/RASDemo/Makefile
@@ -109,7 +109,7 @@ clean:
 	$(OBJCOPY) -O binary $< $@
 
 $(RASLIB)/output/libras.a:
-	$(MAKE) -C $(RASLIB) 
+	$(MAKE) -C $(RASLIB)
 
 %.out: $(OBJ) $(RASLIB)/output/libras.a
 	$(LD) -T $(LDS) -o $@ $(OBJ) $(LDFLAGS)

--- a/RASDemo/Makefile
+++ b/RASDemo/Makefile
@@ -93,15 +93,14 @@ debug: $(TARGET)
 uart:
 	$(SCREEN) $(shell $(DETECT_SCRIPT)) 115200
 
-run: flash
+start: flash
+	$(OPENOCD) -c "init; reset run; shutdown"
+
+run: start
 	$(SCREEN) $(shell $(DETECT_SCRIPT)) 115200
 
 clean:
-	-rm $(TARGET)
-	-rm $(TARGET:.axf=.out)
-	-rm $(ASM)
-	-rm $(OBJ:.o=.d)
-
+	@rm $(OBJ:.o=.d) $(ASM) $(TARGET:.axf=.out) $(TARGET) 2>/dev/null || true
 
 %.a: $(OBJ)
 	$(AR) rcs $@ $^
@@ -109,7 +108,10 @@ clean:
 %.axf: %.out
 	$(OBJCOPY) -O binary $< $@
 
-%.out: $(OBJ)
+$(RASLIB)/output/libras.a:
+	$(MAKE) -C $(RASLIB) 
+
+%.out: $(OBJ) $(RASLIB)/output/libras.a
 	$(LD) -T $(LDS) -o $@ $(OBJ) $(LDFLAGS)
 
 %.o: %.c

--- a/RASLib/Makefile
+++ b/RASLib/Makefile
@@ -79,7 +79,9 @@ size: $(TARGET)
 
 flash: $(TARGET)
 	$(OPENOCD) -c "init"                              \
+	           -c "reset"                             \
 	           -c "halt"                              \
+	           -c "flash probe 0"                     \
 	           -c "flash write_image erase $(TARGET)" \
 	           -c "verify_image $(TARGET)"            \
 	           -c "halt"                              \
@@ -92,19 +94,13 @@ uart:
 	$(SCREEN) $(shell $(DETECT_SCRIPT)) 115200
 
 start: flash
-	$(OPENOCD) -c "init"                              \
-	           -c "reset run"                         \
-	           -c "shutdown"
+	$(OPENOCD) -c "init; reset run; shutdown"
 
 run: start
 	$(SCREEN) $(shell $(DETECT_SCRIPT)) 115200
 
 clean:
-	-rm $(TARGET)
-	-rm $(TARGET:.axf=.out)
-	-rm $(ASM)
-	-rm $(OBJ:.o=.d)
-
+	@rm $(OBJ:.o=.d) $(ASM) $(TARGET:.axf=.out) $(TARGET) 2>/dev/null || true
 
 %.a: $(OBJ)
 	$(AR) rcs $@ $^

--- a/RASLib/Makefile
+++ b/RASLib/Makefile
@@ -91,7 +91,12 @@ debug: $(TARGET)
 uart:
 	$(SCREEN) $(shell $(DETECT_SCRIPT)) 115200
 
-run: flash
+start: flash
+	$(OPENOCD) -c "init"                              \
+	           -c "reset run"                         \
+	           -c "shutdown"
+
+run: start
 	$(SCREEN) $(shell $(DETECT_SCRIPT)) 115200
 
 clean:

--- a/RASLib/detect-board
+++ b/RASLib/detect-board
@@ -3,16 +3,25 @@
 ###############################################################################
 # Quick and dirty script to find the right device path for the LM4F/TM4C across
 # OSes for Rasware.
-# 
-# Tested on x64 Linux and macOS 10.12 (Sierra). Contains much magic.
-############################################################################### 
+#
+# Tested on x64 Linux, macOS 10.12 (Sierra), and WSL Ubuntu 18.04. Contains
+# much magic.
+###############################################################################
 
 UDEV_PATH="/dev/lm4f"
+CACHE_NAME=".detect-board-cache"
+
+set -x
+
+function outputDevice
+{
+    echo "$1" | tee "${CACHE_NAME}" && exit 0
+}
 
 function macOS
 {
     dev=$(system_profiler SPUSBDataType | awk 'BEGIN { RS = "" } $0 ~ /In-Circuit Debug Interface/ {dev=++FNR; print dev}')
-    sn=$(system_profiler SPUSBDataType | awk -v dev=$dev 'BEGIN { RS = ""; FS="\n"} FNR == dev {print $0}' | grep "Serial Number")
+    sn=$(system_profiler SPUSBDataType | awk -v dev="$dev" 'BEGIN { RS = ""; FS="\n"} FNR == dev {print $0}' | grep "Serial Number")
     sn=$(cut -d ':' -f2 <<< $sn | sed 's/ //' | sed 's/.\{1\}$//')
 
     dev_paths=$(find /dev -iname "tty.usbmodem${sn}[a-zA-Z0-9]" 2>/dev/null)
@@ -24,50 +33,55 @@ function macOS
 
     # Make sure this device actually exists:
     if [ -c "${dev_path}" ]; then
-        echo "${dev_path}" && exit 0
+        outputDevice "${dev_path}"
     else
         linux
     fi
 }
 
-function bashOnWin
-{
-    # Not supported yet.
-    linux
-}
+# function wsl
+# {
+    
+# }
 
 function linux
 {
     if [ -c "${UDEV_PATH}" ]; then
-        echo "${UDEV_PATH}" && exit 0
+        outputDevice "${UDEV_PATH}"
     elif [ -c "/dev/ttyACM0" ]; then
-        echo "/dev/ttyACM0" && exit 0
+        outputDevice "/dev/ttyACM0"
     else
         >&2 echo "Sorry, we couldn't find your board. Please make sure it's plugged in and try again."
-        >&2 echo "If this problem persists, file an issue at http://bit.ly/2nziQhj or contact us."
+        >&2 echo "If this problem persists, file an issue at bit.ly/2nziQhj or contact us."
         exit 1
     fi
 }
 
+if [ -f "${CACHE_NAME}" ]; then
+    read dev < "${CACHE_NAME}"
+    [ -c "${dev}" ] && outputDevice "${dev}"
+fi
 
 if [ "$(uname)" == "Darwin" ]; then
     # macOS User!
     macOS
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [ "$(expr substr "$(uname -s)" 1 5)" == "Linux" ]; then
     if grep -q Microsoft /proc/version; then
-        # Bash on Windows:
-        bashOnWin
+        # Windows Subsystem for Linux:
+        wsl
     else
         # Another Linux user!
         linux
     fi
-elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+elif [ "$(expr substr "$(uname -s)" 1 10)" == "MINGW32_NT" ]; then
     >&2 echo "Sorry, Cygwin/MinGW are not supported at this time."
     exit 1
+else
+    >&2 echo "Unknown platform. Please file an issue at bit.ly/2nziQhj or contact us."
 fi
 
 ##########################
 # AUTHOR:  Rahul Butani  #
-# DATE:    Sept 18, 2017 #
-# VERSION: 0.0.0         #
+# DATE:    Oct. 07, 2018 #
+# VERSION: 0.1.0         #
 ##########################

--- a/RASTemplate/Makefile
+++ b/RASTemplate/Makefile
@@ -109,7 +109,7 @@ clean:
 	$(OBJCOPY) -O binary $< $@
 
 $(RASLIB)/output/libras.a:
-	$(MAKE) -C $(RASLIB) 
+	$(MAKE) -C $(RASLIB)
 
 %.out: $(OBJ) $(RASLIB)/output/libras.a
 	$(LD) -T $(LDS) -o $@ $(OBJ) $(LDFLAGS)

--- a/RASTemplate/Makefile
+++ b/RASTemplate/Makefile
@@ -107,7 +107,10 @@ clean:
 %.axf: %.out
 	$(OBJCOPY) -O binary $< $@
 
-%.out: $(OBJ)
+$(RASLIB)/output/libras.a:
+	$(MAKE) -C $(RASLIB) 
+
+%.out: $(OBJ) $(RASLIB)/output/libras.a
 	$(LD) -T $(LDS) -o $@ $(OBJ) $(LDFLAGS)
 
 %.o: %.c

--- a/RASTemplate/Makefile
+++ b/RASTemplate/Makefile
@@ -79,7 +79,9 @@ size: $(TARGET)
 
 flash: $(TARGET)
 	$(OPENOCD) -c "init"                              \
+	           -c "reset"                             \
 	           -c "halt"                              \
+	           -c "flash probe 0"                     \
 	           -c "flash write_image erase $(TARGET)" \
 	           -c "verify_image $(TARGET)"            \
 	           -c "halt"                              \
@@ -91,15 +93,14 @@ debug: $(TARGET)
 uart:
 	$(SCREEN) $(shell $(DETECT_SCRIPT)) 115200
 
-run: flash
+start: flash
+	$(OPENOCD) -c "init; reset run; shutdown"
+
+run: start
 	$(SCREEN) $(shell $(DETECT_SCRIPT)) 115200
 
 clean:
-	-rm $(TARGET)
-	-rm $(TARGET:.axf=.out)
-	-rm $(ASM)
-	-rm $(OBJ:.o=.d)
-
+	@rm $(OBJ:.o=.d) $(ASM) $(TARGET:.axf=.out) $(TARGET) 2>/dev/null || true
 
 %.a: $(OBJ)
 	$(AR) rcs $@ $^

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Compile RASLib by using the [make](<https://en.wikipedia.org/wiki/Make_(software
   ```bash
     make flash
   ```
-  You may get an "Error 1" the first time you run this. This is (for whatever reason) fairly usual. In this case, simply make flash again. If this doesn't help, next make sure your USB device is connected, powered on, and forwarded to your VM if necessary. If you see "shutdown command invoked," press the reset button. This will start the program on your launchpad. If you keep getting Error 1's, make sure you've forwarded your LaunchPad's USB connection to the VM: In the VM, select `Player -> Removable Devices -> Luminary Micro ICDI` and select `Connect`.
+  You may get an "Error 1" the first time you run this. In this case, simply make flash again. If this doesn't help, next make sure your USB device is connected, powered on, and forwarded to your VM if necessary. If you see "shutdown command invoked," press the reset button. This will start the program on your launchpad. If you keep getting Error 1's, make sure you've forwarded your LaunchPad's USB connection to the VM: In the VM, select `Player -> Removable Devices -> Luminary Micro ICDI` and select `Connect`.
   
   Else, if at this point an error message is printed that includes "Error erasing flash with vFlashErase packet", run the following command twice and press the board's reset button:
   ```bash
@@ -212,7 +212,9 @@ Compile RASLib by using the [make](<https://en.wikipedia.org/wiki/Make_(software
     make run
   ```
   
- However, please note openeing the console may give an error if the command was already run before and was detached. If this happens, try running `screen -r` in console.
+  However, please note opening the console may give an error if the command was already run before and was detached. If this happens, try running `screen -r` in console.
+
+  There's also `make start` which will flash your board _and_ reset it.
 
 ### Committing code back to your repo ###
 1. Before you start, you should configure git with both your username and email.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Compile RASLib by using the [make](<https://en.wikipedia.org/wiki/Make_(software
   
   However, please note opening the console may give an error if the command was already run before and was detached. If this happens, try running `screen -r` in console.
 
-  There's also `make start` which will flash your board _and_ reset it.
+  There's also `make start` which will flash your board and start your program _without_ opening the console.
 
 ### Committing code back to your repo ###
 1. Before you start, you should configure git with both your username and email.


### PR DESCRIPTION
Some nice quality of life improvements; namely:
- `make run` actually runs the thing (and `make start` is a thing too!)
- detect-board is less slow
- projects will build RASLib if needed (no more '-lras' link errors)
- and, best of all: no more `make flash` woes!

(and a quick plug in the README)